### PR TITLE
Update rocket to 0.5.0-rc.2 and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ async-std = { version = "1.6.0", features = ["attributes"] }
 serde = { version = "1.0", features = ["derive"] }
 
 # Rocket dependencies
-rocket = "0.5.0-rc.1"
+rocket = "0.5.0-rc.2"
 
 # Benchmark dependencies
 criterion = "0.3.4"

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -6,10 +6,10 @@ use ssr_rs::Ssr;
 use std::fs::read_to_string;
 
 #[get("/")]
-fn index() -> content::Html<String> {
+fn index() -> content::RawHtml<String> {
     let source = read_to_string("./client/dist/ssr/index.js").unwrap();
 
-    content::Html(Ssr::render_to_string(&source, "SSR", None))
+    content::RawHtml(Ssr::render_to_string(&source, "SSR", None))
 }
 
 #[launch]


### PR DESCRIPTION
The `examples/rocket.rs` file was out of date due to a newly released `rc-2` version of the rocket library under `0.5.0` which changed some of the API surface. This PR updates the Cargo.toml to point to the new RC and updates the example to use the new API.