### PR TITLE
Update rusty_v8 (renamed to v8) to 0.44.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 
 [dependencies]
 lazy_static = "1.4.0"
-rusty_v8 = "0.30.0"
+v8 = "0.44.3"
 
 [dev-dependencies]
 

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -1,4 +1,3 @@
-use rusty_v8 as v8;
 use std::collections::HashMap;
 
 pub struct Ssr {}


### PR DESCRIPTION
Updates `rusty_v8` to 0.44.3. The crate was [renamed from `rusty_v8` to `v8` after 0.32.1](https://github.com/denoland/rusty_v8/releases/tag/v0.32.1) so the `src/ssr.rs` file was updated to reflect the new name. The tests pass when including the changes from https://github.com/Valerioageno/ssr-rs/pull/3.