### PR TITLE
WIP(feat): Store Isolate inside API struct which can be reused

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ rocket = "0.5.0-rc.2"
 criterion = "0.3.4"
 env_logger = "0.9.0"
 
+# Multi-threading dependencies
+# object-pool = "0.5.4"
+
 [[bench]]
 name = "benchmark"
 path = "benches/benchmark.rs"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -3,11 +3,13 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ssr_rs::SSREnvironment;
 
 pub fn bench_one_shot_render_no_params(c: &mut Criterion) {
-    let mut env = SSREnvironment::new(&std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(), "SSR", "Index");
+    let mut env = SSREnvironment::new(
+        &std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(),
+        "SSR",
+        "Index",
+    );
 
-    c.bench_function("render_to_string_no_params", |b| {
-        b.iter(|| env.render(""))
-    });
+    c.bench_function("render_to_string_no_params", |b| b.iter(|| env.render("")));
 }
 
 pub fn bench_one_shot_render_with_params(c: &mut Criterion) {
@@ -19,7 +21,11 @@ pub fn bench_one_shot_render_with_params(c: &mut Criterion) {
         ]
     }"##;
 
-    let mut env = SSREnvironment::new(&std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(), "SSR", "Index");
+    let mut env = SSREnvironment::new(
+        &std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(),
+        "SSR",
+        "Index",
+    );
 
     c.bench_function("render_to_string_with_params", |b| {
         b.iter(|| env.render(&mock_props))

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,13 +1,12 @@
 #[allow(unused_imports)]
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use ssr_rs::Ssr;
-use std::fs::read_to_string;
+use ssr_rs::SSREnvironment;
 
 pub fn bench_one_shot_render_no_params(c: &mut Criterion) {
-    let source = read_to_string("./client/dist/ssr/index.js").unwrap();
+    let mut env = SSREnvironment::new(&std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(), "SSR", "Index");
 
     c.bench_function("render_to_string_no_params", |b| {
-        b.iter(|| Ssr::one_shot_render(source.clone(), "SSR", None))
+        b.iter(|| env.render(""))
     });
 }
 
@@ -20,10 +19,10 @@ pub fn bench_one_shot_render_with_params(c: &mut Criterion) {
         ]
     }"##;
 
-    let source = read_to_string("./client/dist/ssr/index.js").unwrap();
+    let mut env = SSREnvironment::new(&std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(), "SSR", "Index");
 
     c.bench_function("render_to_string_with_params", |b| {
-        b.iter(|| Ssr::one_shot_render(source.clone(), "SSR", Some(&mock_props)))
+        b.iter(|| env.render(&mock_props))
     });
 }
 

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -2,7 +2,7 @@ use actix_files as fs;
 use actix_web::{get, http::StatusCode, middleware::Logger, App, HttpResponse, HttpServer};
 use std::fs::read_to_string;
 
-use ssr_rs::Ssr;
+use ssr_rs::SSREnvironment;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
@@ -25,8 +25,8 @@ async fn index() -> HttpResponse {
     let source = read_to_string("./client/dist/ssr/index.js").unwrap();
 
     // This is a benchmark example. Please refer to examples/shared_ssr.rs for a better solution.
-    let js = Ssr::new(source, "SSR");
+    let mut env = SSREnvironment::new(&source, "SSR", "Index");
     HttpResponse::build(StatusCode::OK)
         .content_type("text/html; charset=utf-8")
-        .body(js.render_to_string(None))
+        .body(env.render(""))
 }

--- a/examples/actix_with_initial_props.rs
+++ b/examples/actix_with_initial_props.rs
@@ -22,8 +22,7 @@ async fn main() -> std::io::Result<()> {
 #[get("/")]
 async fn index() -> HttpResponse {
     let source = read_to_string("./client/dist/ssr/index.js").unwrap();
-
-    let js = Ssr::new(source, "SSR");
+    let mut env = SSREnvironment::new(&source, "SSR", "Index");
 
     let mock_props = r##"{
         "params": [
@@ -35,5 +34,5 @@ async fn index() -> HttpResponse {
 
     HttpResponse::build(StatusCode::OK)
         .content_type("text/html; charset=utf-8")
-        .body(js.render_to_string(Some(&mock_props)))
+        .body(env.render(mock_props))
 }

--- a/examples/actix_with_initial_props.rs
+++ b/examples/actix_with_initial_props.rs
@@ -3,7 +3,7 @@ use std::fs::read_to_string;
 
 use actix_files as fs;
 
-use ssr_rs::Ssr;
+use ssr_rs::SSREnvironment;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -2,16 +2,13 @@
 extern crate rocket;
 use rocket::fs::FileServer;
 use rocket::response::content;
-use ssr_rs::Ssr;
-use std::fs::read_to_string;
+use ssr_rs::SSREnvironment;
 
 #[get("/")]
 fn index() -> content::RawHtml<String> {
-    let source = read_to_string("./client/dist/ssr/index.js").unwrap();
+    let mut env = SSREnvironment::new(&std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(), "SSR", "Index");
 
-    let js = Ssr::new(source, "SSR");
-
-    content::RawHtml(js.render_to_string(None))
+    content::RawHtml(env.render(""))
 }
 
 #[launch]

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -6,7 +6,11 @@ use ssr_rs::SSREnvironment;
 
 #[get("/")]
 fn index() -> content::RawHtml<String> {
-    let mut env = SSREnvironment::new(&std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(), "SSR", "Index");
+    let mut env = SSREnvironment::new(
+        &std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(),
+        "SSR",
+        "Index",
+    );
 
     content::RawHtml(env.render(""))
 }

--- a/examples/run.rs
+++ b/examples/run.rs
@@ -1,9 +1,12 @@
 //This example exist just for develop purposes
-use ssr_rs::Ssr;
-use std::fs::read_to_string;
+use ssr_rs::SSREnvironment;
 
 fn main() {
-    let source = read_to_string("./client/dist/ssr/index.js").unwrap();
-
-    println!("{}", Ssr::one_shot_render(source, "SSR", None))
+    SSREnvironment::init();
+    let mut env = SSREnvironment::new(
+        &std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(),
+        "SSR",
+        "Index",
+    );
+    println!("{}", env.render("").expect("Output"))
 }

--- a/examples/run.rs
+++ b/examples/run.rs
@@ -2,11 +2,10 @@
 use ssr_rs::SSREnvironment;
 
 fn main() {
-    SSREnvironment::init();
     let mut env = SSREnvironment::new(
         &std::fs::read_to_string("./client/dist/ssr/index.js").unwrap(),
         "SSR",
         "Index",
     );
-    println!("{}", env.render("").expect("Output"))
+    println!("{}", env.render(""))
 }

--- a/examples/shared_ssr.rs
+++ b/examples/shared_ssr.rs
@@ -1,20 +1,20 @@
 use actix_files as fs;
-use actix_web::{get, http::StatusCode, middleware::Logger, web, App, HttpResponse, HttpServer};
+use actix_web::{get, http::StatusCode, middleware::Logger, /*web,*/ App, HttpResponse, HttpServer};
 use std::fs::read_to_string;
 
-use ssr_rs::Ssr;
+// use ssr_rs::SSREnvironment;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let source = read_to_string("./client/dist/ssr/index.js").unwrap();
+    let _source = read_to_string("./client/dist/ssr/index.js").unwrap();
 
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
 
-    let js = Ssr::new(source, "SSR");
+    // let env = SSREnvironment::new(&source, "SSR", "Index");
     HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
-            .app_data(web::Data::new(js.clone()))
+            // .app_data(web::Data::new(js.clone()))
             .service(fs::Files::new("/styles", "client/dist/ssr/styles/").show_files_listing())
             .service(fs::Files::new("/images", "client/dist/ssr/images/").show_files_listing())
             .service(fs::Files::new("/scripts", "client/dist/client/").show_files_listing())
@@ -26,8 +26,8 @@ async fn main() -> std::io::Result<()> {
 }
 
 #[get("/")]
-async fn index<'a>(js: web::Data<Ssr<'a>>) -> HttpResponse {
+async fn index<'a>(/* js: web::Data<Ssr<'a>> */) -> HttpResponse {
     HttpResponse::build(StatusCode::OK)
         .content_type("text/html; charset=utf-8")
-        .body(js.render_to_string(None))
+        .body("<html></html>")
 }

--- a/examples/shared_ssr.rs
+++ b/examples/shared_ssr.rs
@@ -1,5 +1,7 @@
 use actix_files as fs;
-use actix_web::{get, http::StatusCode, middleware::Logger, /*web,*/ App, HttpResponse, HttpServer};
+use actix_web::{
+    get, http::StatusCode, middleware::Logger, /*web,*/ App, HttpResponse, HttpServer,
+};
 use std::fs::read_to_string;
 
 // use ssr_rs::SSREnvironment;

--- a/examples/tide.rs
+++ b/examples/tide.rs
@@ -1,4 +1,4 @@
-use ssr_rs::Ssr;
+use ssr_rs::SSREnvironment;
 use std::fs::read_to_string;
 use tide::{Request, Response};
 
@@ -15,9 +15,8 @@ async fn main() -> tide::Result<()> {
 
 async fn return_html(_req: Request<()>) -> tide::Result {
     let source = read_to_string("./client/dist/ssr/index.js").unwrap();
-
-    let js = Ssr::new(source, "SSR");
-    let html = js.render_to_string(None);
+    let mut env = SSREnvironment::new(&source, "SSR", "Index");
+    let html = env.render("");
 
     let response = Response::builder(200)
         .body(html)

--- a/examples/warp.rs
+++ b/examples/warp.rs
@@ -1,14 +1,14 @@
 #![deny(warnings)]
-use ssr_rs::Ssr;
+use ssr_rs::SSREnvironment;
 use std::fs::read_to_string;
 use warp::{http::Response, Filter};
 
 #[tokio::main]
 async fn main() {
     let source = read_to_string("./client/dist/ssr/index.js").unwrap();
-
-    let js = Ssr::new(source, "SSR");
-    let html = warp::path::end().map(move || Response::builder().body(js.render_to_string(None)));
+    let html = warp::path::end().map(move || {
+        Response::builder().body(SSREnvironment::new(&source, "SSR", "Index").render(""))
+    });
 
     let css = warp::path("styles").and(warp::fs::dir("./client/dist/ssr/styles/"));
     let scripts = warp::path("scripts").and(warp::fs::dir("./client/dist/client/"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,4 +80,4 @@
 extern crate lazy_static;
 mod ssr;
 
-pub use ssr::Ssr;
+pub use ssr::SSREnvironment;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,18 +15,18 @@
 //!
 //!  # Example
 //!
-//! The whole logic is stored inside the <a href="./struct.Ssr.html#method.render_to_string">render_to_string()</a> function.
+//! The whole logic is stored inside the <a href="./struct.SSREnvironment.html#method.render">render()</a> function.
 //!
 //! ```no_run
-//! use ssr_rs::Ssr;
+//! use ssr_rs::SSREnvironment;
 //! use std::fs::read_to_string;
 //!
 //! fn main() {
 //!     let source = read_to_string("./path/to/build.js").unwrap();
 //!
-//!     let js = Ssr::new(source, "entryPoint");
+//!     let mut env = SSREnvironment::new(&source, "entryPoint", "rootFunction");
 //!
-//!     let html = js.render_to_string(None);
+//!     let html = env.render("");
 //!    
 //!     assert_eq!(html, "<!doctype html><html>...</html>".to_string());
 //! }
@@ -36,7 +36,7 @@
 //!  # Example with initial props
 //!
 //! ```no_run
-//! use ssr_rs::Ssr;
+//! use ssr_rs::SSREnvironment;
 //! use std::fs::read_to_string;
 //!
 //! fn main() {
@@ -51,30 +51,13 @@
 //!
 //!     let source = read_to_string("./path/to/build.js").unwrap();
 //!
-//!     let js = Ssr::new(source, "entryPoint");
+//!     let mut env = SSREnvironment::new(&source, "entryPoint", "rootFunction");
 //!
-//!     let html = js.render_to_string(Some(&props));
+//!     let html = env.render(props);
 //!    
 //!     assert_eq!(html, "<!doctype html><html>...</html>".to_string());
 //! }
 //!```
-//! It's also possible just run the logic in a single shot just with Ssr::one_shot_render()
-//!
-//! # Example single shot
-//!
-//! ```no_run
-//! use ssr_rs::Ssr;
-//! use std::fs::read_to_string;
-//!
-//! fn main() {
-//!
-//!     let source = read_to_string("./path/to/build.js").unwrap();
-//!
-//!     let html = Ssr::one_shot_render(source, "entryPoint", None);
-//!
-//!     assert_eq!(html, "<!doctype html><hmtl>...</html>".to_string());
-//! }
-//! ```
 
 #[macro_use]
 extern crate lazy_static;

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -21,7 +21,7 @@ impl SSREnvironment {
 
     pub fn new(source_code: &str, entry_point: &str, root_export: &str) -> Self {
         Self::init();
-        
+
         // The isolate represents an isolated instance of the v8 engine
         // Object from one isolate must not be used in other isolates.
         let isolate = v8::Isolate::new(Default::default());

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -58,7 +58,7 @@ impl SSREnvironment {
         let script = v8::script_compiler::compile(
             &mut scope,
             v8::script_compiler::Source::new(code, None),
-            if self.script_cache == false {
+            if !self.script_cache {
                 // self.script_cache = true;
                 v8::script_compiler::CompileOptions::NoCompileOptions
             } else {

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -1,156 +1,212 @@
-use std::collections::HashMap;
 
-#[derive(Clone, Debug, PartialEq)]
-pub struct Ssr<'a> {
-    // TODO: Check if better Box<str> instead of String
-    source: String,
-    entry_point: &'a str,
+pub struct SSREnvironment<'a> {
+    function: *mut v8::Local<'a, v8::Function>,
+    scope: *mut v8::ContextScope<'a, v8::HandleScope<'a>>,
+    context: *mut v8::Local<'a, v8::Context>,
+    handle_scope: *mut v8::HandleScope<'a, ()>,
+    isolate: *mut v8::OwnedIsolate,
 }
 
-impl<'a> Ssr<'a> {
-    /// Create an instance of the Ssr struct instanciate the v8 platform as well.
-    pub fn new(source: String, entry_point: &'a str) -> Self {
-        Self::init_platform();
-
-        Ssr {
-            source,
-            entry_point,
-        }
-    }
-
-    fn init_platform() {
+impl SSREnvironment<'_> {
+    pub fn init() {
         lazy_static! {
-          static ref INIT_PLATFORM: () = {
-              //Initialize a new V8 platform
-              let platform = v8::new_default_platform(0, false).make_shared();
-              v8::V8::initialize_platform(platform);
-              v8::V8::initialize();
-          };
+            static ref INIT_PLATFORM: () = {
+                //Initialize a new V8 platform
+                let platform = v8::new_default_platform(0, false).make_shared();
+                v8::V8::initialize_platform(platform);
+                v8::V8::initialize();
+            };
         }
 
         lazy_static::initialize(&INIT_PLATFORM);
     }
 
-    /// Evaluates the javascript source code passed as argument and render it as a String.
-    /// Any initial params (if needed) must be passed as JSON.
-    ///
-    /// <a href="https://github.com/Valerioageno/ssr-rs/blob/main/examples/actix_with_initial_props.rs" target="_blank">Here</a> an useful example of how to use initial params with the actix framework.
-    ///
-    /// "enrty_point" is the variable name set from the frontend bundler used. <a href="https://github.com/Valerioageno/ssr-rs/blob/main/client/webpack.ssr.js" target="_blank">Here</a> an example from webpack.
-    pub fn one_shot_render(source: String, entry_point: &str, params: Option<&str>) -> String {
-        Self::init_platform();
+    pub fn new(source: &str, entry_point: &str, root_export: &str) -> Self {
+        // @todo: Add safety explanation.
 
-        Self::render(source, entry_point, params)
-    }
+        // The isolate represents an isolated instance of the v8 engine
+        // Object from one isolate must not be used in other isolates.
+        let isolate: *mut _ = Box::leak(Box::new(v8::Isolate::new(Default::default())));
 
-    /// Evaluates the JS source code instanciate in the Ssr struct
-    /// "enrty_point" is the variable name set from the frontend bundler used. <a href="https://github.com/Valerioageno/ssr-rs/blob/main/client/webpack.ssr.js" target="_blank">Here</a> an example from webpack.
-    pub fn render_to_string(&self, params: Option<&str>) -> String {
-        Self::render(self.source.clone(), self.entry_point, params)
-    }
+        // A stack-allocated class that governs a number of local handles.
+        let handle_scope: *mut _ =
+            Box::leak(Box::new(v8::HandleScope::new(unsafe { &mut *isolate })));
 
-    fn render(source: String, entry_point: &str, params: Option<&str>) -> String {
-        //The isolate rapresente an isolated instance of the v8 engine
-        //Object from one isolate must not be used in other isolates.
-        let isolate = &mut v8::Isolate::new(Default::default());
+        // A sandboxed execution context with its own set of built-in objects and functions.
+        let context: *mut _ = Box::leak(Box::new(v8::Context::new(unsafe { &mut *handle_scope })));
 
-        //A stack-allocated class that governs a number of local handles.
-        let handle_scope = &mut v8::HandleScope::new(isolate);
+        // Stack-allocated class which sets the execution context for all operations executed within a local scope.
+        let scope: *mut _ = Box::leak(Box::new(v8::ContextScope::new(
+            unsafe { &mut *handle_scope },
+            unsafe { *context },
+        )));
 
-        //A sandboxed execution context with its own set of built-in objects and functions.
-        let context = v8::Context::new(handle_scope);
+        let scope_borrow = unsafe { &mut *scope };
 
-        //Stack-allocated class which sets the execution context for all operations executed within a local scope.
-        let scope = &mut v8::ContextScope::new(handle_scope, context);
-
-        let code = v8::String::new(scope, &format!("{};{}", source, entry_point))
-            .expect("Invalid JS: Strings are needed");
-
-        let script = v8::Script::compile(scope, code, None)
-            .expect("Invalid JS: There aren't runnable scripts");
-
-        let exports = script
-            .run(scope)
-            .expect("Invalid JS: Missing entry point. Is the bundle exported as a variable?");
-
-        let object = exports
-            .to_object(scope)
-            .expect("Invalid JS: There are no objects");
-
-        let fn_map = Self::create_fn_map(scope, object);
-
-        let params: v8::Local<v8::Value> = match v8::String::new(scope, params.unwrap_or("")) {
-            Some(s) => s.into(),
-            None => v8::undefined(scope).into(),
-        };
-
-        let undef = v8::undefined(scope).into();
-
-        let mut rendered = String::new();
-
-        for key in fn_map.keys() {
-            let result = fn_map[key].call(scope, undef, &[params]).unwrap();
-
-            let result = result
-                .to_string(scope)
-                .expect("Failed to parse the result to string");
-
-            rendered = format!("{}{}", rendered, result.to_rust_string_lossy(scope));
-        }
-
-        rendered
-    }
-
-    fn create_fn_map<'b>(
-        scope: &mut v8::ContextScope<'b, v8::HandleScope>,
-        object: v8::Local<v8::Object>,
-    ) -> HashMap<String, v8::Local<'b, v8::Function>> {
-        let mut fn_map: HashMap<String, v8::Local<v8::Function>> = HashMap::new();
-
-        if let Some(props) = object.get_own_property_names(scope) {
-            fn_map = Some(props)
-                .iter()
-                .enumerate()
-                .map(|(i, &p)| {
-                    let name = p.get_index(scope, i as u32).unwrap();
-
-                    //A HandleScope which first allocates a handle in the current scope which will be later filled with the escape value.
-                    let mut scope = v8::EscapableHandleScope::new(scope);
-
-                    let func = object.get(&mut scope, name).unwrap();
-
-                    let func = unsafe { v8::Local::<v8::Function>::cast(func) };
-
-                    (
-                        name.to_string(&mut scope)
-                            .unwrap()
-                            .to_rust_string_lossy(&mut scope),
-                        scope.escape(func),
-                    )
-                })
-                .collect();
-        }
-
-        fn_map
-    }
-}
-
-#[cfg(tests)]
-mod tests {
-
-    #[test]
-    fn check_struct_instance() {
-        let js = Ssr::new(
-            r##"var SSR = {x: () => "<html></html>"};"##.to_string(),
-            "SSR",
-        );
-
-        assert_eq!(
-            js,
-            Ssr {
-                source: r##"var SSR = {x: () => "<html></html>"};"##.to_string(),
-                entry_point: "SSR"
-            }
+        let code: *mut _ = Box::leak(Box::new(v8::String::new(
+            scope_borrow,
+            // We add the "entry_point" to the end of the file so
+            // we can get the value of the Webpack bundle as output
+            // when the script is run. See: "object" below which
+            // refers to the output of the script.
+            &format!("{};{}", source, entry_point),
         )
+        .expect("Invalid JS: Strings are needed")));
+
+        let script: *mut _ = Box::leak(Box::new(
+            v8::Script::compile(scope_borrow, unsafe { *code }, None)
+                .expect("Invalid JS: There aren't runnable scripts"),
+        ));
+
+        let script_exports: *mut _ =
+            Box::leak(Box::new(unsafe { *script }.run(scope_borrow).expect(
+                "Invalid JS: Missing entry point. Is the bundle exported as a variable?",
+            )));
+
+        let object: *mut _ = Box::leak(Box::new(unsafe { *script_exports }
+            .to_object(scope_borrow)
+            .expect("Invalid JS: entry_point not found. Are you sure you used the right value for entry_point?")));
+
+        let root_export_v8: *mut _ = Box::leak(Box::new(v8::String::new(scope_borrow, root_export)
+            .expect("Failed to allocate string.")
+            .into()));
+
+        let function: *mut _ = Box::leak(Box::new(
+            unsafe { &mut *object }
+                .get(scope_borrow, unsafe { *root_export_v8 })
+                .expect("Invalid JS: Failed to find root export function."),
+        ));
+
+        let function_value = unsafe { *function };
+        let function: *mut v8::Local<v8::Function> =
+            unsafe { &mut v8::Local::<v8::Function>::cast(function_value) };
+
+        SSREnvironment {
+            function,
+            scope,
+            context,
+            handle_scope,
+            isolate,
+        }
+    }
+
+    pub fn render(&mut self, params: &str) -> Option<String> {
+        // @todo: Add safety explanation.
+        let scope = unsafe { &mut *self.scope };
+        let function = unsafe { &mut *self.function };
+
+        let params = v8::String::new(scope, params).expect("Failed to allocate params string.");
+        let undefined = v8::undefined(scope);
+        let result = function
+            .call(scope, undefined.into(), &[params.into()])
+            .expect("Failed to call function.");
+
+        Some(result.to_rust_string_lossy(scope))
     }
 }
+
+impl Drop for SSREnvironment<'_> {
+    fn drop(&mut self) {
+        // @todo: Drop fields in order.
+        todo!();
+    }
+}
+
+// #[derive(Clone, Debug, PartialEq)]
+// pub struct Ssr<'a> {
+//     // TODO: Check if better Box<str> instead of String
+//     source: String,
+//     entry_point: &'a str,
+// }
+
+// impl<'a> Ssr<'a> {
+//     /// Create an instance of the Ssr struct instanciate the v8 platform as well.
+//     pub fn new(source: String, entry_point: &'a str) -> Self {
+//         Self::init_platform();
+
+//         Ssr {
+//             source,
+//             entry_point,
+//         }
+//     }
+
+//     fn init_platform() {
+//
+//     }
+
+//     /// Evaluates the javascript source code passed as argument and render it as a String.
+//     /// Any initial params (if needed) must be passed as JSON.
+//     ///
+//     /// <a href="https://github.com/Valerioageno/ssr-rs/blob/main/examples/actix_with_initial_props.rs" target="_blank">Here</a> an useful example of how to use initial params with the actix framework.
+//     ///
+//     /// "enrty_point" is the variable name set from the frontend bundler used. <a href="https://github.com/Valerioageno/ssr-rs/blob/main/client/webpack.ssr.js" target="_blank">Here</a> an example from webpack.
+//     pub fn one_shot_render(source: String, entry_point: &str, params: Option<&str>) -> String {
+//         Self::init_platform();
+
+//         Self::render(source, entry_point, params)
+//     }
+
+//     /// Evaluates the JS source code instanciate in the Ssr struct
+//     /// "enrty_point" is the variable name set from the frontend bundler used. <a href="https://github.com/Valerioageno/ssr-rs/blob/main/client/webpack.ssr.js" target="_blank">Here</a> an example from webpack.
+//     pub fn render_to_string(&self, params: Option<&str>) -> String {
+//         Self::render(self.source.clone(), self.entry_point, params)
+//     }
+
+//     fn render(source: String, entry_point: &str, params: Option<&str>) -> String {
+
+//
+//     }
+
+//     fn create_fn_map<'b>(
+//         scope: &mut v8::ContextScope<'b, v8::HandleScope>,
+//         object: v8::Local<v8::Object>,
+//     ) -> HashMap<String, v8::Local<'b, v8::Function>> {
+//         let mut fn_map: HashMap<String, v8::Local<v8::Function>> = HashMap::new();
+
+//         if let Some(props) = object.get_own_property_names(scope) {
+//             fn_map = Some(props)
+//                 .iter()
+//                 .enumerate()
+//                 .map(|(i, &p)| {
+//                     let name = p.get_index(scope, i as u32).unwrap();
+
+//                     //A HandleScope which first allocates a handle in the current scope which will be later filled with the escape value.
+//                     let mut scope = v8::EscapableHandleScope::new(scope);
+
+//                     let func = object.get(&mut scope, name).unwrap();
+
+//                     let func = unsafe { v8::Local::<v8::Function>::cast(func) };
+
+//                     (
+//                         name.to_string(&mut scope)
+//                             .unwrap()
+//                             .to_rust_string_lossy(&mut scope),
+//                         scope.escape(func),
+//                     )
+//                 })
+//                 .collect();
+//         }
+
+//         fn_map
+//     }
+// }
+
+// #[cfg(tests)]
+// mod tests {
+
+//     #[test]
+//     fn check_struct_instance() {
+//         let js = Ssr::new(
+//             r##"var SSR = {x: () => "<html></html>"};"##.to_string(),
+//             "SSR",
+//         );
+
+//         assert_eq!(
+//             js,
+//             Ssr {
+//                 source: r##"var SSR = {x: () => "<html></html>"};"##.to_string(),
+//                 entry_point: "SSR"
+//             }
+//         )
+//     }
+// }

--- a/tests/lib_check.rs
+++ b/tests/lib_check.rs
@@ -48,22 +48,15 @@ fn render_simple_html() {
 
 #[test]
 fn render_from_struct_instance() {
-    let mut env = SSREnvironment::new(
-        &r##"var SSR = {x: () => "<html></html>"};"##,
-        "SSR",
-        "x"
-    );
+    let mut env = SSREnvironment::new(&r##"var SSR = {x: () => "<html></html>"};"##, "SSR", "x");
 
     assert_eq!(env.render(""), "<html></html>");
-    assert_eq!(
-        env.render(r#"{"Hello world"}"#),
-        "<html></html>"
-    );
+    assert_eq!(env.render(r#"{"Hello world"}"#), "<html></html>");
 
     let mut env = SSREnvironment::new(
         r##"var SSR = {x: () => "I don't accept params"};"##,
         "SSR",
-        "x"
+        "x",
     );
 
     assert_eq!(env.render(""), "I don't accept params");

--- a/tests/lib_check.rs
+++ b/tests/lib_check.rs
@@ -1,74 +1,70 @@
+use ssr_rs::SSREnvironment;
+
 #[test]
 #[should_panic]
 fn incorrect_entry_point() {
     let source = r##"var entryPoint = {x: () => "<html></html>"};"##;
+    let mut env = SSREnvironment::new(source, "IncorrectEntryPoint", "Index");
 
-    let _ = Ssr::one_shot_render(source.to_owned(), "IncorrectEntryPoint", None);
+    let _ = env.render("");
 }
 
 #[test]
 #[should_panic]
 fn empty_code() {
     let source = r##""##;
+    let mut env = SSREnvironment::new(source, "SSR", "Index");
 
-    let _ = Ssr::one_shot_render(source.to_owned(), "SSR", None);
+    let _ = env.render("");
 }
 
 #[test]
 fn pass_param_to_function() {
     let props = r#"{"Hello world"}"#;
-
     let accept_params_source =
         r##"var SSR = {x: (params) => "These are our parameters: " + params};"##.to_string();
-
-    let result = Ssr::one_shot_render(accept_params_source.clone(), "SSR", Some(&props));
-
+    let result = SSREnvironment::new(&accept_params_source, "SSR", "x").render(props);
     assert_eq!(result, "These are our parameters: {\"Hello world\"}");
 
     let no_params_source = r##"var SSR = {x: () => "I don't accept params"};"##.to_string();
-
-    let result2 = Ssr::one_shot_render(no_params_source, "SSR", Some(&props));
-
+    let result2 = SSREnvironment::new(&no_params_source, "SSR", "x").render("");
     assert_eq!(result2, "I don't accept params");
 
-    let result3 = Ssr::one_shot_render(accept_params_source, "SSR", None);
-
+    let result3 = SSREnvironment::new(&accept_params_source, "SSR", "x").render("");
     assert_eq!(result3, "These are our parameters: ");
 }
 
 #[test]
 fn render_simple_html() {
     let source = r##"var SSR = {x: () => "<html></html>"};"##;
-
-    let html = Ssr::one_shot_render(source.to_owned(), "SSR", None);
-
+    let html = SSREnvironment::new(&source, "SSR", "x").render("");
     assert_eq!(html, "<html></html>");
 
-    //Prevent missing semicolon
+    // Prevent missing semicolon
     let source2 = r##"var SSR = {x: () => "<html></html>"}"##;
-
-    let html2 = Ssr::one_shot_render(source2.to_owned(), "SSR", None);
-
+    let html2 = SSREnvironment::new(&source2, "SSR", "x").render("");
     assert_eq!(html2, "<html></html>");
 }
 
 #[test]
 fn render_from_struct_instance() {
-    let js = Ssr::new(
-        r##"var SSR = {x: () => "<html></html>"};"##.to_string(),
+    let mut env = SSREnvironment::new(
+        &r##"var SSR = {x: () => "<html></html>"};"##,
         "SSR",
+        "x"
     );
 
-    assert_eq!(js.render_to_string(None), "<html></html>");
+    assert_eq!(env.render(""), "<html></html>");
     assert_eq!(
-        js.render_to_string(Some(r#"{"Hello world"}"#)),
+        env.render(r#"{"Hello world"}"#),
         "<html></html>"
     );
 
-    let js2 = Ssr::new(
-        r##"var SSR = {x: () => "I don't accept params"};"##.to_string(),
+    let mut env = SSREnvironment::new(
+        r##"var SSR = {x: () => "I don't accept params"};"##,
         "SSR",
+        "x"
     );
 
-    assert_eq!(js2.render_to_string(None), "I don't accept params");
+    assert_eq!(env.render(""), "I don't accept params");
 }

--- a/tests/lib_check.rs
+++ b/tests/lib_check.rs
@@ -1,5 +1,3 @@
-use ssr_rs::Ssr;
-
 #[test]
 #[should_panic]
 fn incorrect_entry_point() {


### PR DESCRIPTION
Having the library user keep track of the Isolate instance improves performance by 5x from my tests in the benches. This could be further improved by multi-threading since the user can create a new Isolate (SSREnvironment) for each thread. We need to figure out an example to provide. There's a few more performance tweaks to be had:
- [ ] Reusing [CachedData](https://docs.rs/v8/latest/v8/script_compiler/struct.CachedData.html) for script compilation
- [ ] Reusing Context