### PR TITLE
chore: update v8 to 0.68.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build-and-test:
     docker:
-      - image: cimg/rust:1.57.0-node
+      - image: cimg/rust:1.68.2-node
     environment:
       RUSTFLAGS: "-D warnings"
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/lib.rs"
 
 [dependencies]
 lazy_static = "1.4.0"
-v8 = "0.44.3"
+v8 = "0.68.0"
 
 [dev-dependencies]
 

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -107,7 +107,7 @@ impl<'a> Ssr<'a> {
     ) -> HashMap<String, v8::Local<'b, v8::Function>> {
         let mut fn_map: HashMap<String, v8::Local<v8::Function>> = HashMap::new();
 
-        if let Some(props) = object.get_own_property_names(scope) {
+        if let Some(props) = object.get_own_property_names(scope, Default::default()) {
             fn_map = Some(props)
                 .iter()
                 .enumerate()


### PR DESCRIPTION
title says it all- updates the v8 dependency to the latest version, and updates the `get_own_property_names` to use the default value for the `GetPropertyNamesArgs` param.