### PR TITLE
Ssr lib return results

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The project aims to enable server side rendering on rust servers in the simplest
 
 It use an embedded version of the v8 javascript engine (<a href="https://github.com/denoland/rusty_v8" target="_blank">rusty_v8</a>) to parse and evaluate a built bundle file and return a string with the rendered html.
 
-Currently it works with Webpack bundler v5.65.0; check it out <a href="https://github.com/Valerioageno/reactix" target="_blank">here</a> a full project who use this crate.
+Currently it works with Webpack bundler v5.65.0.
 
 ## Getting started
 
@@ -32,9 +32,9 @@ fn main() {
 
     let source = read_to_string("./path/to/build.js").unwrap();
 
-    let mut js = Ssr::new(&source, "entryPoint");
+    let mut js = Ssr::new(&source, "entryPoint").unwrap();
 
-    let html = js.render_to_string(None);
+    let html = js.render_to_string(None).unwrap();
     
     assert_eq!(html, "<!doctype html><html>...</html>".to_string());
 }
@@ -60,11 +60,62 @@ fn main() {
 
     let source = read_to_string("./path/to/build.js").unwrap();
 
-    let mut js = Ssr::new(&source, "entryPoint");
+    let mut js = Ssr::new(&source, "entryPoint").unwrap();
 
-    let html = js.render_to_string(Some(&props));
+    let html = js.render_to_string(Some(&props)).unwrap();
 
     assert_eq!(html, "<!doctype html><html>...</html>".to_string());
+}
+```
+
+## Example with actix-web
+
+> Examples with different web frameworks are available in the <a href="https://github.com/Valerioageno/ssr-rs/blob/main/examples" target="_blank">examples</a> folder.
+
+Even though the V8 engine allows accessing the same `isolate` from different threads that is forbidden by this crate for two reasons:
+
+1. rusty_v8 library have not implemented yet the V8 Locker API. Accessing Ssr struct from a different thread will make the V8 engine to panic.
+2. Rendering HTML does not need shared state across threads.
+
+For this reason parallel computation is a better choice. Following actix-web setup:
+
+```rust
+use actix_web::{get, http::StatusCode, App, HttpResponse, HttpServer};
+use std::cell::RefCell;
+use std::fs::read_to_string;
+
+use ssr_rs::Ssr;
+
+thread_local! {
+    static SSR: RefCell<Ssr<'static, 'static>> = RefCell::new(
+            Ssr::from(
+                read_to_string("./client/dist/ssr/index.js").unwrap(),
+                "SSR"
+                ).unwrap()
+            )
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+
+    Ssr::create_platform();
+
+    HttpServer::new(|| {
+        App::new()
+            .service(index)
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}
+
+#[get("/")]
+async fn index() -> HttpResponse {
+    let result = SSR.with(|ssr| ssr.borrow_mut().render_to_string(None).unwrap());
+
+    HttpResponse::build(StatusCode::OK)
+        .content_type("text/html; charset=utf-8")
+        .body(result)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ssr_rs = "0.2.3"
+ssr_rs = "0.3.0"
 ```
 
 ## Example

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -39,7 +39,7 @@ async fn index() -> HttpResponse {
     let start = Instant::now();
     let result = SSR.with(|ssr| ssr.borrow_mut().render_to_string(None).unwrap());
     println!("Elapsed: {:?}", start.elapsed());
-    // This is a benchmark example. Please refer to examples/shared_ssr.rs for a better solution.
+
     HttpResponse::build(StatusCode::OK)
         .content_type("text/html; charset=utf-8")
         .body(result)

--- a/examples/actix.rs
+++ b/examples/actix.rs
@@ -11,7 +11,7 @@ thread_local! {
             Ssr::from(
                 read_to_string("./client/dist/ssr/index.js").unwrap(),
                 "SSR"
-                )
+                ).unwrap()
             )
 }
 
@@ -37,7 +37,7 @@ async fn main() -> std::io::Result<()> {
 #[get("/")]
 async fn index() -> HttpResponse {
     let start = Instant::now();
-    let result = SSR.with(|ssr| ssr.borrow_mut().render_to_string(None));
+    let result = SSR.with(|ssr| ssr.borrow_mut().render_to_string(None).unwrap());
     println!("Elapsed: {:?}", start.elapsed());
     // This is a benchmark example. Please refer to examples/shared_ssr.rs for a better solution.
     HttpResponse::build(StatusCode::OK)

--- a/examples/actix_with_initial_props.rs
+++ b/examples/actix_with_initial_props.rs
@@ -11,7 +11,7 @@ thread_local! {
             Ssr::from(
                 read_to_string("./client/dist/ssr/index.js").unwrap(),
                 "SSR"
-                )
+                ).unwrap()
             )
 }
 
@@ -42,5 +42,5 @@ async fn index() -> HttpResponse {
 
     HttpResponse::build(StatusCode::OK)
         .content_type("text/html; charset=utf-8")
-        .body(SSR.with(|ssr| ssr.borrow_mut().render_to_string(Some(mock_props))))
+        .body(SSR.with(|ssr| ssr.borrow_mut().render_to_string(Some(mock_props)).unwrap()))
 }

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -9,7 +9,7 @@ thread_local! {
             Ssr::from(
                 read_to_string("./client/dist/ssr/index.js").unwrap(),
                 "SSR"
-                )
+                ).unwrap()
             )
 }
 
@@ -29,5 +29,5 @@ async fn root() -> Html<String> {
     let start = Instant::now();
     let result = SSR.with(|ssr| ssr.borrow_mut().render_to_string(None));
     println!("Elapsed: {:?}", start.elapsed());
-    Html(result)
+    Html(result.unwrap())
 }

--- a/examples/multi-thread.rs
+++ b/examples/multi-thread.rs
@@ -9,7 +9,7 @@ thread_local! {
             Ssr::from(
                 read_to_string("./client/dist/ssr/index.js").unwrap(),
                 "SSR"
-                )
+                ).unwrap()
             )
 }
 
@@ -23,7 +23,7 @@ fn main() {
                 let start = Instant::now();
                 println!(
                     "result: {}",
-                    SSR.with(|ssr| ssr.borrow_mut().render_to_string(None))
+                    SSR.with(|ssr| ssr.borrow_mut().render_to_string(None).unwrap())
                 );
                 println!(
                     "Thread #{i} finished! - Elapsed time: {:?}",

--- a/examples/rocket.rs
+++ b/examples/rocket.rs
@@ -12,7 +12,7 @@ thread_local! {
             Ssr::from(
                 read_to_string("./client/dist/ssr/index.js").unwrap(),
                 "SSR"
-                )
+                ).unwrap()
             )
 }
 
@@ -21,7 +21,7 @@ fn index() -> content::RawHtml<String> {
     let start = Instant::now();
     let result = SSR.with(|ssr| ssr.borrow_mut().render_to_string(None));
     println!("Elapsed: {:?}", start.elapsed());
-    content::RawHtml(result)
+    content::RawHtml(result.unwrap())
 }
 
 #[launch]

--- a/examples/run.rs
+++ b/examples/run.rs
@@ -8,9 +8,9 @@ fn main() {
     Ssr::create_platform();
 
     // This takes roughly 40ms
-    let mut ssr = Ssr::from(source, "SSR");
+    let mut ssr = Ssr::from(source, "SSR").unwrap();
 
     // This takes roughly 0.5ms
-    println!("{}", ssr.render_to_string(None));
-    println!("{}", ssr.render_to_string(None));
+    println!("{}", ssr.render_to_string(None).unwrap());
+    println!("{}", ssr.render_to_string(None).unwrap());
 }

--- a/examples/tide.rs
+++ b/examples/tide.rs
@@ -9,7 +9,7 @@ thread_local! {
             Ssr::from(
                 read_to_string("./client/dist/ssr/index.js").unwrap(),
                 "SSR"
-                )
+                ).unwrap()
             )
 }
 
@@ -31,7 +31,7 @@ async fn return_html(_req: Request<()>) -> tide::Result {
     println!("Elapsed: {:?}", start.elapsed());
 
     let response = Response::builder(200)
-        .body(html)
+        .body(html.unwrap())
         .content_type(tide::http::mime::HTML)
         .build();
 

--- a/examples/warp.rs
+++ b/examples/warp.rs
@@ -10,7 +10,7 @@ thread_local! {
             Ssr::from(
                 read_to_string("./client/dist/ssr/index.js").unwrap(),
                 "SSR"
-                )
+                ).unwrap()
             )
 }
 
@@ -22,7 +22,7 @@ async fn main() {
         let start = Instant::now();
         let result = SSR.with(|ssr| ssr.borrow_mut().render_to_string(None));
         println!("Elapsed: {:?}", start.elapsed());
-        Response::builder().body(result)
+        Response::builder().body(result.unwrap())
     });
 
     let css = warp::path("styles").and(warp::fs::dir("./client/dist/ssr/styles/"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@
 //!
 //! It use an embedded version of the v8 javascript engine (<a href="https://github.com/denoland/rusty_v8" target="_blank">rusty_v8</a>) to parse and evaluate a built bundle file and return a string with the rendered html.
 //!
-//! Currently it works with Webpack bundler v4.44.2; check it out  <a href="https://github.com/Valerioageno/reactix" target="_blank">here</a> a full project who use this crate.
+//! Currently it works with Webpack bundler v4.44.2.
 //!
-//!  # Gettin started
+//!  # Getting started
 //! ```toml
 //! [dependencies]
 //! ssr_rs = "0.3.0"
@@ -63,7 +63,55 @@
 //!     assert_eq!(html, "<!doctype html><html>...</html>".to_string());
 //! }
 //!```
-
+//!
+//! # Example with actix-web
+//!
+//! > Examples with different web frameworks are available in the <a href="https://github.com/Valerioageno/ssr-rs/blob/main/examples" target="_blank">examples</a> folder.
+//!
+//! Even though the V8 engine allows accessing the same `isolate` from different threads that is forbidden by this crate for two reasons:
+//! 1. rusty_v8 library have not implemented yet the V8 Locker API. Accessing Ssr struct from a different thread will make the V8 engine to panic.
+//! 2. Rendering HTML does not need shared state across threads.
+//!
+//!  For this reason parallel computation is a better choice. Following actix-web setup:
+//!
+//! ```rust
+//! use actix_web::{get, http::StatusCode, App, HttpResponse, HttpServer};
+//! use std::cell::RefCell;
+//! use std::fs::read_to_string;
+//!
+//! use ssr_rs::Ssr;
+//!
+//! thread_local! {
+//!    static SSR: RefCell<Ssr<'static, 'static>> = RefCell::new(
+//!        Ssr::from(
+//!            read_to_string("./client/dist/ssr/index.js").unwrap(),
+//!            "SSR"
+//!            ).unwrap()
+//!    )
+//!}
+//!
+//! #[actix_web::main]
+//!async fn main() -> std::io::Result<()> {
+//!    Ssr::create_platform();
+//!
+//!    HttpServer::new(|| {
+//!        App::new()
+//!            .service(index)
+//!        })
+//!        .bind("127.0.0.1:8080")?
+//!        .run()
+//!        .await
+//! }
+//!
+//! #[get("/")]
+//! async fn index() -> HttpResponse {
+//!    let result = SSR.with(|ssr| ssr.borrow_mut().render_to_string(None).unwrap());
+//!
+//!    HttpResponse::build(StatusCode::OK)
+//!        .content_type("text/html; charset=utf-8")
+//!        .body(result)
+//! }
+//!```
 mod ssr;
 
 pub use ssr::Ssr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@
 //!
 //!     let source = read_to_string("./path/to/build.js").unwrap();
 //!
-//!     let mut js = Ssr::from(source, "entryPoint");
+//!     let mut js = Ssr::from(source, "entryPoint").unwrap();
 //!
-//!     let html = js.render_to_string(None);
+//!     let html = js.render_to_string(None).unwrap();
 //!    
 //!     assert_eq!(html, "<!doctype html><html>...</html>".to_string());
 //! }
@@ -56,9 +56,9 @@
 //!
 //!     let source = read_to_string("./path/to/build.js").unwrap();
 //!
-//!     let mut js = Ssr::from(source, "entryPoint");
+//!     let mut js = Ssr::from(source, "entryPoint").unwrap();
 //!
-//!     let html = js.render_to_string(Some(&props));
+//!     let html = js.render_to_string(Some(&props)).unwrap();
 //!    
 //!     assert_eq!(html, "<!doctype html><html>...</html>".to_string());
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //!
 //!  For this reason parallel computation is a better choice. Following actix-web setup:
 //!
-//! ```rust
+//! ```no_run
 //! use actix_web::{get, http::StatusCode, App, HttpResponse, HttpServer};
 //! use std::cell::RefCell;
 //! use std::fs::read_to_string;


### PR DESCRIPTION
This PR let the end user to handle failure situations autonomously returning from the `from` and `render_to_string` methods a `Result` enum. 

The crate now panics only if the V8 engine itself panics