### PR TITLE
Update Svelte version in docs

### DIFF
--- a/examples/vite-svelte/backend/main.rs
+++ b/examples/vite-svelte/backend/main.rs
@@ -10,7 +10,7 @@ thread_local! {
             read_to_string(Path::new("./dist/server/server.js").to_str().unwrap()).unwrap(),
             ""
         ).unwrap_or_else(|err| {
-            eprintln!("Failed to initialize SSR: {}", err);
+            eprintln!("Failed to initialize SSR: {err}");
             std::process::exit(1);
         })
     )
@@ -21,7 +21,7 @@ async fn index(res: &mut Response) {
     let result = SSR.with(|ssr| {
         let mut ssr = ssr.borrow_mut();
         ssr.render_to_string(None).unwrap_or_else(|err| {
-            eprintln!("Error rendering to string: {}", err);
+            eprintln!("Error rendering to string: {err}");
             String::new()
         })
     });
@@ -38,7 +38,7 @@ async fn index(res: &mut Response) {
     let result: serde_json::Value = match serde_json::from_str(&result) {
         Ok(val) => val,
         Err(err) => {
-            eprintln!("Failed to parse JSON: {}", err);
+            eprintln!("Failed to parse JSON: {err}");
             res.status_code(StatusCode::INTERNAL_SERVER_ERROR);
             res.render(Text::Plain("Internal Server Error"));
             return;
@@ -53,14 +53,13 @@ async fn index(res: &mut Response) {
         <html>
         <head>
             <link rel="stylesheet" href="/client/assets/main.css">
-            {}
+            {head}
         </head>
         <body>
-            <div id="svelte-app">{}</div>
+            <div id="svelte-app">{body}</div>
             <script type="module" src="/client/main.js"></script>
         </body>
-        </html>"#,
-        head, body
+        </html>"#
     );
     res.render(Text::Html(full_html));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ℹ️ **This project is the backbone of [tuono](https://github.com/Valerioageno/tuono); a fullstack react framework with built in SSR.**
 //!
-//! Currently it works with [Vite](https://vitejs.dev/), [Webpack](https://webpack.js.org/), [Rspack](https://www.rspack.dev/), [React 18](https://react.dev/) and [Svelte 4](https://svelte.dev/) - Check the <a href="https://github.com/Valerioageno/ssr-rs/blob/main/examples" target="_blank">examples</a> folder.
+//! Currently it works with [Vite](https://vitejs.dev/), [Webpack](https://webpack.js.org/), [Rspack](https://www.rspack.dev/), [React 18](https://react.dev/) and [Svelte 5](https://svelte.dev/) - Check the <a href="https://github.com/Valerioageno/ssr-rs/blob/main/examples" target="_blank">examples</a> folder.
 //!
 //! > Check <a href="https://github.com/Valerioageno/ssr-rs/blob/main/benches">here</a> the
 //! > benchmarks results.

--- a/src/ssr.rs
+++ b/src/ssr.rs
@@ -15,7 +15,7 @@ pub enum SsrError {
 
 impl fmt::Display for SsrError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 


### PR DESCRIPTION
The actual example was updated to use Svelte 5, but the docs still indicates that the example uses Svelte 4.